### PR TITLE
add cafe_github_org landing page with first draft of text and tables

### DIFF
--- a/handbook/_toc.yml
+++ b/handbook/_toc.yml
@@ -11,8 +11,7 @@ parts:
     - file: examples
   - caption: CAFÉ GitHub Organization
     chapters:
-    - url: https://github.com/Climate-CAFE/
-      title: Climate CAFÉ GitHub Organization 
+    - file: cafe_github_org
     - file: github
     - file: template
   - caption: Additional Resources

--- a/handbook/cafe_github_org.md
+++ b/handbook/cafe_github_org.md
@@ -1,0 +1,33 @@
+# Climate CAFÉ GitHub Organization
+
+## Climate & Health Tutorials and Code Sharing
+
+CAFÉ RCC has a established a [community GitHub organization](https://github.com/Climate-CAFE) to share code, examples, and tutorials on working with common data formats and sources. We are assembling a collection of standard operating procedures (SOPs) for data processing, integration, harmonization, and analysis with code and tutorials in order to facilitate reproducibility and reusability for the climate and health Community of Practice.  
+
+The CAFÉ Data Management Function team has begun to develop and share code and tutorials that cover tasks such as spatial aggregations, data harmonization, and analysis across languages including R and Python. As the CAFÉ community grows to include more of the climate and health Community of Practice, we will continue to refine and expand these materials to showcase additional analyses platforms (e.g., ArcGIS). We also hope that community members joining the CAFÉ initiative will contribute, share, and reuse code and software within the CAFÉ GitHub.
+
+## Current Tutorials and Code Walkthroughs
+
+Our team members have created tutorials and code examples for several key data management procedures and common analysis challenges that climate and health researchers may encounter. These tutorials are intended to provide usable example materials that researchers can download and step through on their own.
+
+Many of these materials are still under active development, so please check back regularly for updates.
+
+### Live Tutorials and Code
+
+| Title | Description | Repository Link |
+| --- | --- | --- |
+| **Population Weighting Raster Data** | Using the gridded meteorological dataset PRISM as an example, this tutorial demonstrates how to aggregate raster data to administrative units (e.g., counties) with population weights. | https://github.com/Climate-CAFE/population_weighting_raster_data |
+<!-- | **Basic Data Join Tutorial** | ... | https://github.com/Climate-CAFE/join_tutorial_basic |
+| **Census Tutorial** | ... | https://github.com/Climate-CAFE/census_tutorial | -->
+
+### Under Development
+
+| Title | Description |
+| --- | --- |
+| **Introduction to Bash Scripting** | This tutorial will explain the purpose of bash scripting on computing clusters and provides sample code for executing a bash script. |
+| **Overview of ZIP Codes and Zip Code Tabulation Areas (ZCTAs)** | This tutorial will provide an overview of the differences between ZIP Codes and Zip Code Tabulation Areas and provides code for creating a crosswalk between ZIP Codes and ZCTAs. |
+| **Discrete Variable Spatial Aggregation** | This tutorial will help researchers explore and understand the process of the spatial aggregation for discrete variables. It will provide the Python code to guide you through various steps of producing spatial aggregation from 1km tiff raster to county polygons for the [Koppen-Geiger climate types](https://www.nature.com/articles/sdata2018214) data. |
+
+## Expanding Our Efforts
+
+We hope that in addition to learning from these tutorials, community members will see these materials as representative examples of the kinds of materials they can develop and share through the CAFÉ themselves. If you are interested in contributing a tutorial or example workflow to the CAFÉ yourself, please contact us about joining CAFÉ Github organization or having your existing Github repository added to CAFÉ through a new fork, so that we can share your materials with the broader climate and health Community of Practice.


### PR DESCRIPTION
This update contains the new landing page for the CAFE Github resources. Text on this page is ready for review, and the tables provide the first entries for ready and upcoming tutorial repositories. Additional repositories will be added as they become ready to deply and/or as their in-progress descriptions are prepared for the "Under Development" table.