### PR TITLE
Update _toc.yml w Data Selection Guide

### DIFF
--- a/handbook/_toc.yml
+++ b/handbook/_toc.yml
@@ -9,6 +9,8 @@ parts:
       title: Climate-Health CAFÉ Dataverse Collection 
     - file: tutorial
     - file: examples
+    - url: https://docs.google.com/document/d/1QqQNPglXXB-W8Oj5_GEjP5egrfWIdQBFtVdiG0WAN9c/edit?tab=t.0#heading=h.ax5a1isl8mnb
+      title: Dataset Selection Tips and Tricks
   - caption: CAFÉ GitHub Organization
     chapters:
     - file: cafe_github_org


### PR DESCRIPTION
Adding Dataset Selection Tips and Tricks to TOC for DM page.

This would create a link under the CAFE Dataverse Collection header to a View Only version of the Google Doc with Data selection guidelines